### PR TITLE
Bugfix + user $http_function with namespace

### DIFF
--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -88,7 +88,7 @@ class Subscriber {
      * @return mixed
      */
     public function subscribe($topic_url, $http_function = false) {
-        return $this->change_subscription("subscribe", $topic_url, $http_function = false);
+        return $this->change_subscription("subscribe", $topic_url, $http_function);
     }
 
     /**
@@ -97,7 +97,7 @@ class Subscriber {
      * @return mixed
      */
     public function unsubscribe($topic_url, $http_function = false) {
-        return $this->change_subscription("unsubscribe", $topic_url, $http_function = false);
+        return $this->change_subscription("unsubscribe", $topic_url, $http_function);
     }
 
     /**
@@ -129,7 +129,7 @@ class Subscriber {
         // make the http post request and return true/false
         // easy to over-write to use your own http function
         if ($http_function)
-            return $http_function($this->hub_url,$post_string);
+            return call_user_func_array($http_function,array($this->hub_url,$post_string));
         else
             return $this->http($this->hub_url,$post_string);
     }


### PR DESCRIPTION
- bugfix in subscribe() and unsubscribe() -> http_function was always false
- use call_user_func_array() to allow user functions in custom classes/namespaces