### PR TITLE
Give a default value to the param $post_string in http()

### DIFF
--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -181,7 +181,7 @@ class Subscriber
      *
      * @return mixed
      */
-    private function http($url, $post_string)
+    private function http($url, $post_string = false)
     {
 
         // add any additional curl options here


### PR DESCRIPTION
Hey, thanks for updating PHP version requirements.
I wasn't able to test all of the functionality live (our code doesn't use all of the features of this library), but I did use PHPStan to statically analyze the code--it should catch most of what would be an issue for PHP 8. This pull request is a fix for the only issue it found:

The private function http() is called with and without the $post_string parameter; I added a default value of `false` to indicated that.

If this looks good and is merged, it would also be helpful if you could also do a new release to Packagist. Thanks for your work on this!